### PR TITLE
fix leak storage for cache

### DIFF
--- a/gatherer/internal/cache/sqlite/cache.go
+++ b/gatherer/internal/cache/sqlite/cache.go
@@ -58,14 +58,16 @@ func New(path string) (*Cache, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, err := newDB.Exec(`PRAGMA synchronous = 0`); err != nil {
+		if _, errSync := newDB.Exec(`PRAGMA synchronous = 0`); errSync != nil {
 			newDB.Close()
-			return nil, err
+			return nil, errSync
 		}
-		if _, err := newDB.Exec(`PRAGMA journal_mode = OFF`); err != nil {
+		if _, errJournal := newDB.Exec(`PRAGMA journal_mode = OFF`); errJournal != nil {
 			newDB.Close()
-			return nil, err
+			return nil, errJournal
 		}
+		newDB.SetMaxOpenConns(1)
+		newDB.SetMaxIdleConns(1)
 		listOfOpenCaches.list[path] = newDB
 		result.db = newDB
 		go result.rotateOldTablesRoutine()

--- a/plugins/init.lua
+++ b/plugins/init.lua
@@ -38,9 +38,10 @@ function is_rds()
 end
 
 -- return unix ts from connection
-function get_unix_ts(conn)
+function get_unix_ts(conn, ts)
   conn = conn or target
-  return conn:query("select extract(epoch from now())::int").rows[1][1]
+  ts = ts or 1
+  return conn:query("select extract(epoch from now())::int - (extract(epoch from now())::int % $1)", ts).rows[1][1]
 end
 
 -- insert metric with plugin:host()


### PR DESCRIPTION
try to fix:
```2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/alerts/cache.sqlite rotate old tables: database is locked
2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/sender/cache.sqlite rotate old tables: database is locked
2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/activity/cache.sqlite rotate old tables: database is locked
2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/bgwriter/cache.sqlite rotate old tables: database is locked
2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/block/cache.sqlite rotate old tables: database is locked
2019/09/30 09:43:47 [ERROR] cache /cache/timescaledb/buffercache/cache.sqlite rotate old tables: database is locke```