### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build and push Docker images
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vadv/pg_gatherer_test
         dockerfile: ./docker/test.Dockerfile
@@ -29,7 +29,7 @@ jobs:
       run: docker run --rm vadv/pg_gatherer:test bash -ec "make test_in_docker"
 
     - name: Build and push Docker images
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vadv/pg_gatherer
         dockerfile: ./docker/release.Dockerfile

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build test image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vadv/pg_gatherer_test
         dockerfile: ./docker/test.Dockerfile
@@ -23,7 +23,7 @@ jobs:
       run: docker run --rm vadv/pg_gatherer_test bash -ec "make test_in_docker"
 
     - name: Build release docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vadv/pg_gatherer
         dockerfile: ./docker/release.Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore